### PR TITLE
fix: do not ask for enter on exit if the script was started using CLI parameters

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -525,5 +525,6 @@ if(__name__ == '__main__'):
         os.makedirs(dst)
 
     main(url, dst, not img, not vid, start_offset, end_offset, full_hash)
-    input('---Press enter to exit---')
-    stdout.write('\n')
+    if(confirm):
+        input('---Press enter to exit---')
+        stdout.write('\n')


### PR DESCRIPTION
This PR should fix the issue mentioned in https://github.com/A-Coom/coomer.party-scraper/issues/12