### PR TITLE
fix: suppress escape sequence warning for Python >= 3.12

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -428,7 +428,7 @@ def main(url, dst, imgs, vids, start_offs, end_offs, full_hash):
             return
 
     # Sanitize the URL
-    url = 'https://www.' + re.sub('(www\.)|(https?://)', '', url)
+    url = 'https://www.' + re.sub(r'(www\.)|(https?://)', '', url)
     if(url[-1] == '/'): url = url[:-1]
     url_sections = url.split('/')
     if(len(url_sections) < 4):


### PR DESCRIPTION
Starting from Python 3.12 a warning gets thrown for invalid escape sequences within a python string. This is the case for the URL sanitizing as well. To avoid that, the string needs to be a raw string.

https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes