### PR TITLE
fix: raise errors on streamed media downloads using requests

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -53,6 +53,7 @@ class CoomerThread(DownloadThread):
             try:
                 headers = start > 0 and { 'Range': f'bytes={start}-' } or {}
                 res = requests.get(self.url, headers=headers, stream=True, allow_redirects=True)
+                res.raise_for_status()
                 break
             except:
                 self.throttle()


### PR DESCRIPTION
This fixes the issue https://github.com/A-Coom/coomer.party-scraper/issues/14 by raising http errors as exceptions even during streamed download of the media files. This way the error handling in the CoomerThread works as it was intended to do also for other http status codes, e.g. 403, 404, 502, etc.