### PR TITLE
Build a docker container using Github Actions automatically

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,98 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: '22 9 * * *'
+  push:
+    branches: [ "main" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        with:
+          cosign-release: 'v2.2.4'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 
 [submodule "scraping_utils"]
 	path = scraping_utils
-	url = ./scraping_utils/
+	url = ../scraping_utils/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT [ "python", "./scrape.py" ]

--- a/scrape.py
+++ b/scrape.py
@@ -429,7 +429,7 @@ def main(url, dst, imgs, vids, start_offs, end_offs, full_hash):
             return
 
     # Sanitize the URL
-    url = 'https://www.' + re.sub('(www\.)|(https?://)', '', url)
+    url = 'https://www.' + re.sub(r'(www\.)|(https?://)', '', url)
     if(url[-1] == '/'): url = url[:-1]
     url_sections = url.split('/')
     if(len(url_sections) < 4):

--- a/scrape.py
+++ b/scrape.py
@@ -53,6 +53,7 @@ class CoomerThread(DownloadThread):
             try:
                 headers = start > 0 and { 'Range': f'bytes={start}-' } or {}
                 res = requests.get(self.url, headers=headers, stream=True, allow_redirects=True)
+                res.raise_for_status()
                 break
             except:
                 self.throttle()

--- a/scrape.py
+++ b/scrape.py
@@ -526,5 +526,6 @@ if(__name__ == '__main__'):
         os.makedirs(dst)
 
     main(url, dst, not img, not vid, start_offset, end_offset, full_hash)
-    input('---Press enter to exit---')
-    stdout.write('\n')
+    if(confirm):
+        input('---Press enter to exit---')
+        stdout.write('\n')


### PR DESCRIPTION
This includes all changes of the already existing PRs https://github.com/A-Coom/coomer.party-scraper/pull/17, https://github.com/A-Coom/coomer.party-scraper/pull/16 and https://github.com/A-Coom/coomer.party-scraper/pull/15 and adds the Dockerfile and Github workflow to automatically build a docker image on every merge into master branch.

With this, you are able to run the script in a docker environment. In my case I can run docker containers on my NAS and start them regularly to scrape different creators. For this I use a docker compose file with one entry per creator I want to scrape:
```
  scraper-CREATORNAME:
    image: ghcr.io/lee5002/coomer.party-scraper:main
    volumes:
      - "/PATH/ON/YOUR/HOST:/out"
    command: -o ./out/CREATORNAME --full-hash CREATORLINK
```