### PR TITLE
added a rate limiter & templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.py[cod]
 *.ruff_cache/
 build/
+.idea/

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ coomerscraper
 ### Advanced Usage
 
 ```
-usage: coomerscraper [-h] [-c] [--dump-urls] [-j JOBS] [--log-file LOG_FILE] [--log-level LOG_LEVEL]
-                     [--offset-end END] [--offset-start START] [-o OUT] [--skip-imgs] [--skip-vids]
-                     [urls ...]
+usage: run.py [-h] [-c] [--dump-urls] [-j JOBS] [--log-file LOG_FILE] [--log-level LOG_LEVEL]
+              [--offset-end END] [--offset-start START] [-o OUT] [--skip-imgs] [--skip-vids]
+              [--rate-limit RATE_LIMIT] [urls ...]
 
 Coomer and Kemono scraper
 
@@ -58,12 +58,15 @@ options:
   --dump-urls           print the urls to a text file instead of downloading
   -j, --jobs JOBS       number of concurrent download threads (default: 4)
   --log-file LOG_FILE   direct logs to a file instead of stdout
-  --log-level LOG_LEVEL level of logging (DEBUG, INFO, WARNING, ERROR; default: INFO)
+  --log-level LOG_LEVEL
+                        level of logging (DEBUG, INFO, WARNING, ERROR; default: INFO)
   --offset-end END      ending offset to finish downloading
   --offset-start START  starting offset to begin downloading
   -o, --out OUT         download destination (default: CWD)
   --skip-imgs           skip image downloads
   --skip-vids           skip video downloads
+  --rate-limit RATE_LIMIT
+                        rate limit in requests/s (default: 2)
 ```
 
 The URL can be a page for a creator, a post from a creator, or a single media file. The starting and ending offsets are only respected when downloading from a page. When downloading a single media file, the creator name cannot be determined, thus goes in a subfolder named "unknown."

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ coomerscraper
 ```
 usage: coomerscraper [-h] [-c] [--dump-urls] [-j JOBS] [--log-file LOG_FILE] [--log-level LOG_LEVEL]
               [--offset-end END] [--offset-start START] [-o OUT] [--skip-imgs] [--skip-vids]
-              [--rate-limit RATE_LIMIT] [urls ...]
+              [--rate-limit RATE_LIMIT] [--template TEMPLATE] [--image-template IMAGE_TEMPLATE]
+              [--video-template VIDEO_TEMPLATE] [urls ...]
 
 Coomer and Kemono scraper
 
@@ -63,6 +64,11 @@ options:
   --skip-vids           skip video downloads
   --rate-limit RATE_LIMIT
                         rate limit in requests/s (default: 2)
+  --template TEMPLATE   <tags>
+  --image-template IMAGE_TEMPLATE
+                        <tags>
+  --video-template VIDEO_TEMPLATE
+                        <tags>        
 ```
 
 The URL can be a page for a creator, a post from a creator, or a single media file. The starting and ending offsets are only respected when downloading from a page. When downloading a single media file, the creator name cannot be determined, thus goes in a subfolder named "unknown."

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ coomerscraper
 ### Advanced Usage
 
 ```
-usage: run.py [-h] [-c] [--dump-urls] [-j JOBS] [--log-file LOG_FILE] [--log-level LOG_LEVEL]
+usage: coomerscraper [-h] [-c] [--dump-urls] [-j JOBS] [--log-file LOG_FILE] [--log-level LOG_LEVEL]
               [--offset-end END] [--offset-start START] [-o OUT] [--skip-imgs] [--skip-vids]
               [--rate-limit RATE_LIMIT] [urls ...]
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Example Output: [ServiceName] CreatorName/PostTitle/0-filename.jpg
 ```
 
 ### Via media type
-You can also set different templates for images or videos This can be done by using the following flags:
+You can also set different templates for images or videos. This can be done by using the following flags:
 ```
 --image-template <tags>
 --video-template <tags>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If a release is not available for your platform, follow the instructions to inst
 
 ## Install Python Module
 
-If you don't want to (or are unable to) use a packaged release, you can install the tool as a Python module by running the the following command while in the directory containing the pyproject.toml file.
+If you don't want to (or are unable to) use a packaged release, you can install the tool as a Python module by running the following command while in the directory containing the pyproject.toml file.
 
 ```sh
 python3 -m pip install .
@@ -35,10 +35,6 @@ python3 -m coomerscraper
 # Option 2: Run as a standalone command
 coomerscraper
 ```
-
-
-
-
 
 ### Advanced Usage
 
@@ -74,12 +70,34 @@ The URL can be a page for a creator, a post from a creator, or a single media fi
 If the URL is omitted, then you will be prompted for all parameters during execution.
 
 
+## Templates
+Templates allow you to customize the folder and file naming structure to your liking. The following tags are available to use:
+```
+<t:service>   :  creator platform
+<t:creator>   :  creator name
+<t:post>      :  post title
+<t:index>     :  file index
+<t:filename>  :  file name
+<t:filehash>  :  file hash
+<t:extension> :  file extension
+<t:date>      :  published date (YYYYMMDD)
+<t:id>        :  post id
 
+Example Template: [<t:service>] <t:creator>/<t:post>/<t:index>-<t:filename>.<t:extension>
+Example Output: [ServiceName] CreatorName/PostTitle/0-filename.jpg
+```
 
+### Via media type
+You can also set different templates for images or videos This can be done by using the following flags:
+```
+--image-template <tags>
+--video-template <tags>
+```
+The same tags apply, however the `--template` flag must be set first.
 
 ## Docker Container
 
-Github actions is used to automatically build a new Docker image on every push to the main branch. You can use the Docker container with all the normal arguments. This could be an example configuration of a Docker compose file scraping multiple creators:
+GitHub actions is used to automatically build a new Docker image on every push to the main branch. You can use the Docker container with all the normal arguments. This could be an example configuration of a Docker compose file scraping multiple creators:
 
 ```
 services:
@@ -107,7 +125,7 @@ docker run -v /PATH/ON/YOUR/HOST:/app coomerscraper LINK1 LINK2
 - **Do not include usernames anywhere in your issue**. Search engines may match these and result in DMCA problems.
 - Provide a detailed description of the issue, including operating system, Python version, and any program arguments (redact all usernames).
 - Create a log file using the arguments `--log-level DEBUG --log-file short_description.log`.
-- Remove any usernames from the log file (URLs, file names, etc) before attaching it to your issue.
+- Remove any usernames from the log file (URLs, file names, etc.) before attaching it to your issue.
 
 Please do not open an issue if you are having problems with `python3`, `pip`, or your `PATH` unless it is specifically related to the scraper.
 

--- a/src/coomerscraper/__main__.py
+++ b/src/coomerscraper/__main__.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 Parse the program arguments or read them from stdin
 """
 def get_arguments() -> Tuple[List[str], Path, bool, bool, Tuple[int,int], bool, int]:
-        # Initialize arguments for CLI use
+    # Initialize arguments for CLI use
     parser = argparse.ArgumentParser(description='Coomer and Kemono scraper')
     parser.exit_on_error = False
     parser.add_argument('urls', type=str, nargs='*', help='coomer or kemono URLs to scrape media from, separated by a space')
@@ -30,6 +30,8 @@ def get_arguments() -> Tuple[List[str], Path, bool, bool, Tuple[int,int], bool, 
     parser.add_argument('-o', '--out', type=str, default=os.getcwd(), help='download destination (default: CWD)')
     parser.add_argument('--skip-imgs', action='store_true', help='skip image downloads')
     parser.add_argument('--skip-vids', action='store_true', help='skip video downloads')
+    #new flags
+    parser.add_argument('--rate-limit', type=int, default=2, help='rate limit in requests/s (default: 2)')
 
     # Handle the special case of logging data
     log_file = None
@@ -78,6 +80,8 @@ def get_arguments() -> Tuple[List[str], Path, bool, bool, Tuple[int,int], bool, 
         offs_end = args.end
         dump_urls = args.dump_urls
         jobs = args.jobs
+        rate_limit = args.rate_limit
+
         assert len(urls) > 0
         logger.debug('Usage: non-interactive')
 
@@ -95,9 +99,11 @@ def get_arguments() -> Tuple[List[str], Path, bool, bool, Tuple[int,int], bool, 
         offs_end = None
         dump_urls = False
         confirm = True
+        rate_limit = input('Enter rate limit in req/s (default: 2): ')
+        rate_limit = int(rate_limit) if rate_limit.isdigit() else 2
 
     # Allow the user to confirm information
-    if(confirm):
+    if confirm:
         print()
         logger.info(f'Scraping media from {urls}')
         logger.info(f'Media will be downloaded to {dst}')
@@ -106,22 +112,24 @@ def get_arguments() -> Tuple[List[str], Path, bool, bool, Tuple[int,int], bool, 
         logger.info(f'Starting offset is {offs_start}')
         logger.info(f'Ending offset is {offs_end}')
         logger.info(f'There will be {jobs} concurrent download threads')
+        logger.info(f'Rate limit is {rate_limit} requests/s')
         print()
         confirmed = input('Continue to download (Y/n): ')
         if len(confirmed) > 0 and confirmed.lower()[0] != 'y':
             exit()
 
     # Return parsed arguments
-    return urls, Path(dst), skip_img, skip_vid, (offs_start, offs_end), dump_urls, jobs
+    return urls, Path(dst), skip_img, skip_vid, (offs_start, offs_end), dump_urls, jobs, rate_limit
 
 
 
 """
 Driver function to handle argument parsing and sanity checks before going to coomer-specific details
 """
+
 def main():
     # Get the program arguments or read them from stdin
-    urls, dst, skip_img, skip_vid, offsets, dump_urls, jobs = get_arguments()
+    urls, dst, skip_img, skip_vid, offsets, dump_urls, jobs, rate_limit = get_arguments()
 
     # Sanity check skip flags
     if skip_img and skip_vid:
@@ -144,7 +152,7 @@ def main():
     urls = [ sanitize_url(u) for u in urls ]
 
     # Proceed with coomer-specific details...
-    coom_main(urls, dst, skip_img, skip_vid, offsets, dump_urls, jobs)
+    coom_main(urls, dst, skip_img, skip_vid, offsets, dump_urls, jobs, rate_limit)
     
 
 

--- a/src/coomerscraper/__main__.py
+++ b/src/coomerscraper/__main__.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, Any
 
 from .coom import main as coom_main
 from .utils import sanitize_url
@@ -15,7 +15,8 @@ logger = logging.getLogger(__name__)
 """
 Parse the program arguments or read them from stdin
 """
-def get_arguments() -> Tuple[List[str], Path, bool, bool, Tuple[int,int], bool, int]:
+def get_arguments() -> tuple[list[str] | Any, Path, str | bool | Any, str | bool | Any, tuple[
+    Any | None, Any | None], bool | Any, Any, int | Any]:
     # Initialize arguments for CLI use
     parser = argparse.ArgumentParser(description='Coomer and Kemono scraper')
     parser.exit_on_error = False
@@ -32,7 +33,9 @@ def get_arguments() -> Tuple[List[str], Path, bool, bool, Tuple[int,int], bool, 
     parser.add_argument('--skip-vids', action='store_true', help='skip video downloads')
     #new flags
     parser.add_argument('--rate-limit', type=int, default=2, help='rate limit in requests/s (default: 2)')
-
+    parser.add_argument('--template', type=str, default=None, help='<tags>')
+    parser.add_argument('--image-template', type=str, default=None, help='<tags>')
+    parser.add_argument('--video-template', type=str, default=None, help='<tags>')
     # Handle the special case of logging data
     log_file = None
     log_lvl = logging.INFO
@@ -81,6 +84,9 @@ def get_arguments() -> Tuple[List[str], Path, bool, bool, Tuple[int,int], bool, 
         dump_urls = args.dump_urls
         jobs = args.jobs
         rate_limit = args.rate_limit
+        template = args.template
+        image_template = args.image_template
+        video_template = args.video_template
 
         assert len(urls) > 0
         logger.debug('Usage: non-interactive')
@@ -101,6 +107,9 @@ def get_arguments() -> Tuple[List[str], Path, bool, bool, Tuple[int,int], bool, 
         confirm = True
         rate_limit = input('Enter rate limit in req/s (default: 2): ')
         rate_limit = int(rate_limit) if rate_limit.isdigit() else 2
+        template = None
+        image_template = None
+        video_template = None
 
     # Allow the user to confirm information
     if confirm:
@@ -113,13 +122,19 @@ def get_arguments() -> Tuple[List[str], Path, bool, bool, Tuple[int,int], bool, 
         logger.info(f'Ending offset is {offs_end}')
         logger.info(f'There will be {jobs} concurrent download threads')
         logger.info(f'Rate limit is {rate_limit} requests/s')
+        if template:
+            logger.info(f'Using custom template: {template}')
+        if image_template:
+            logger.info(f'Using image template {image_template}')
+        if video_template:
+            logger.info(f'Using video template {video_template}')
         print()
         confirmed = input('Continue to download (Y/n): ')
         if len(confirmed) > 0 and confirmed.lower()[0] != 'y':
             exit()
 
     # Return parsed arguments
-    return urls, Path(dst), skip_img, skip_vid, (offs_start, offs_end), dump_urls, jobs, rate_limit
+    return urls, Path(dst), skip_img, skip_vid, (offs_start, offs_end), dump_urls, jobs, rate_limit, template, image_template, video_template
 
 
 
@@ -129,7 +144,7 @@ Driver function to handle argument parsing and sanity checks before going to coo
 
 def main():
     # Get the program arguments or read them from stdin
-    urls, dst, skip_img, skip_vid, offsets, dump_urls, jobs, rate_limit = get_arguments()
+    urls, dst, skip_img, skip_vid, offsets, dump_urls, jobs, rate_limit, template, image_template, video_template= get_arguments()
 
     # Sanity check skip flags
     if skip_img and skip_vid:
@@ -148,11 +163,15 @@ def main():
             logger.error('Ending offset must be >= starting offset')
             return
 
+        if image_template or video_template and not template:
+            logger.error('Media-specific templates require a base template to be set')
+            return
+
     # Sanitize argument URLs
     urls = [ sanitize_url(u) for u in urls ]
 
     # Proceed with coomer-specific details...
-    coom_main(urls, dst, skip_img, skip_vid, offsets, dump_urls, jobs, rate_limit)
+    coom_main(urls, dst, skip_img, skip_vid, offsets, dump_urls, jobs, rate_limit, template, image_template, video_template)
     
 
 

--- a/src/coomerscraper/coom.py
+++ b/src/coomerscraper/coom.py
@@ -9,6 +9,7 @@ from .networking import ( api_fetch_post_multi, api_fetch_post_single
 from .utils import base_url, compute_file_hashes, create_folder_tree, round_offsets, to_camel
 
 from .rate_limiter import RateLimiter
+from .template import TemplateManager, PathTemplate
 
 POSTS_PER_FETCH = 50
 
@@ -21,26 +22,67 @@ Extract media URLs from a list of post JSONs
 - posts: List of post JSONs to parse
 - skip_img: If images should be skipped
 - skip_vid: if videos should be skipped
+- service: Service name
+- creator: Creator username
+- template_manager: Template manager for custom paths 
+- use_template: If templates should be used for naming
 Returns a list of NamedUrl extracted from the posts
 """
 def parse_posts_json( base: str
                     , posts: List[dict]
                     , skip_img: bool
-                    , skip_vid: bool ) -> List[NamedUrl]:
+                    , skip_vid: bool
+                    , service: str = ''
+                    , creator: str = ''
+                    , template_manager: Optional[TemplateManager] = None
+                    , use_template: bool = False) -> List[NamedUrl]:
     named_urls = []
     base = base.replace('https://', 'https://n1.')
-    for post in posts:
-        title = to_camel(re.sub(r'[^A-Za-z0-9\s]+', '', post['title']))
-        datetime = re.sub('-|:', '', post['published'])
+
+    for idx, post in enumerate(posts):
+        raw_title = post.get('title', '') or ''
+        title = re.sub(r'[^A-Za-z0-9\s\-_]', '_', raw_title)
+        title = re.sub(r'_+', '_', title)
+        title = re.sub(r'\s+', ' ', title).strip() #maybe allow emojis later
+        if not title:
+            title = post.get('id', '')
+
+        datetime = re.sub('[-:]', '', post['published'])
+        post_id = post.get('id', post['id'])
+
         if 'path' in post['file']:
             ext = post['file']['path'].split('.')[-1]
             if skip_vid and ext in VID_EXTS:
                 continue
-            if skip_img and ext in IMG_EXTS:
+            elif skip_img and ext in IMG_EXTS:
                 continue
-            name = f'{datetime}-{title}_0.{ext}'
-            url = f'{base}/data/{post["file"]["path"]}'
-            named_urls.append(NamedUrl(url, name))
+            else:
+                url = f'{base}/data/{post["file"]["path"]}'
+                if use_template and template_manager:
+                    basename = post['file']['name']
+                    filename = basename.split('.', 1)[0]
+                    m = re.search(r'([0-9a-f]{16,64})', filename)
+                    file_hash = m.group(1) if m else filename
+
+                    context = {
+                        'service': service,
+                        'creator': creator,
+                        'post': title or post_id,
+                        'index': 0,
+                        'filename': filename,
+                        'filehash': file_hash,
+                        'extension': f'.{ext}',
+                        'date': post['published'].split("T")[0].replace("-", ""),
+                        'id': post_id
+                    }
+
+                    is_image = ext in IMG_EXTS
+                    is_video = ext in VID_EXTS
+                    custom_path = template_manager.get_path(context, is_image=is_image, is_video=is_video)
+                    name = str(custom_path.relative_to(template_manager.output_dir))
+                else:
+                    name = f'{datetime}-{title}_0.{ext}'
+                named_urls.append(NamedUrl(url, name))
 
         for i, attachment in enumerate(post['attachments']):
             ext = attachment['path'].split('.')[-1]
@@ -48,12 +90,34 @@ def parse_posts_json( base: str
                 continue
             if skip_img and ext in IMG_EXTS:
                 continue
+
             url = f'{base}/data/{attachment["path"]}'
-            name = f'{datetime}-{title}_{i+1}.{ext}'
+            if use_template and template_manager:
+                basename = post['file']['name']
+                filename = basename.split('.', 1)[0]
+                m = re.search(r'([0-9a-f]{16,64})', filename)
+                file_hash = m.group(1) if m else filename
+
+                context = {
+                    'service': service,
+                    'creator': creator,
+                    'post': title or post_id,
+                    'index': str(i + 1),
+                    'filename': filename,
+                    'filehash': file_hash,
+                    'extension': f'.{ext}',
+                    'date': post['published'].split("T")[0].replace("-", ""),
+                    'id': post_id
+                }
+
+                is_image = ext in IMG_EXTS
+                is_video = ext in VID_EXTS
+                custom_path = template_manager.get_path(context, is_image=is_image, is_video=is_video)
+                name = str(custom_path.relative_to(template_manager.output_dir))
+            else:
+                name = f'{datetime}-{title}_{i+1}.{ext}'
             named_urls.append(NamedUrl(url, name))
     return named_urls
-
-
 
 """
 Process a pre-fetched media URL
@@ -92,7 +156,8 @@ Returns a list of NamedUrl extracted from the post.
 def process_post( url: str
                 , skip_img: bool
                 , skip_vid: bool
-                , rate_limiter: Optional[RateLimiter] = None) -> List[NamedUrl]:
+                , rate_limiter: Optional[RateLimiter] = None
+                , template_manager: Optional[TemplateManager] = None) -> List[NamedUrl]:
     # Get the SLD and TLD of the URL
     base = base_url(url)
     segments = url.split('/')
@@ -108,7 +173,10 @@ def process_post( url: str
 
     # Parse the media URLs from the post
     logger.info('Parsing media URLs from 1 post')
-    named_urls = parse_posts_json(base, post, skip_img, skip_vid)
+
+    use_template = template_manager is not None
+    named_urls = parse_posts_json(base, post, skip_img, skip_vid, service, creator, template_manager, use_template)
+
     logger.info(f'Found {len(named_urls)} media files to download')
 
     # Remove duplicates by finding multiple posts that show the same media
@@ -129,13 +197,15 @@ Process a page to get all media URLs.
 - skip_vid: If video downloads should be skipped.
 - offsets: Range of offsets to download.
 - rate_limiter: Rate limiter for API requests.
+- template_manager: Template manager for custom paths
 Returns a list of NamedUrl extracted from all posts belonging to the page.
 """
 def process_page( url: str
                 , skip_img: bool
                 , skip_vid: bool
                 , offsets: Tuple[Optional[int], Optional[int]]
-                , rate_limiter: Optional[RateLimiter] = None) -> List[NamedUrl]:
+                , rate_limiter: Optional[RateLimiter] = None
+                , template_manager: Optional[TemplateManager] = None) -> List[NamedUrl]:
     # Get the SLD and TLD of the URL
     base = base_url(url)
     segments = url.split('/')
@@ -170,7 +240,10 @@ def process_page( url: str
 
     # Parse the media URLs from each post
     logger.info(f'Parsing media URLs from {len(all_posts)} posts')
-    named_urls = parse_posts_json(base, all_posts, skip_img, skip_vid)
+
+    use_template = template_manager is not None
+    named_urls = parse_posts_json(base, all_posts, skip_img, skip_vid, service, creator, template_manager, use_template)
+
     logger.info(f'Found {len(named_urls)} media files to download')
 
     # Remove duplicates by finding multiple posts that show the same media
@@ -188,7 +261,7 @@ Remove duplicate URLs based on the SHA-256 hash of existing files.
 Note that since URLs are hashes, there should be no duplicates between posts.
 - dst: Directory to check for existing files.
 - named_urls: URLs to remove duplicates from.
-Returns a possibily reduced list of URLs
+Returns a possibly reduced list of URLs
 """
 def purge_duplicate_urls(dst: Path, named_urls: List[NamedUrl]) -> List[NamedUrl]:
     # Get the hashes of the existing files
@@ -215,6 +288,9 @@ Driver function to download media from Coomer or Kemono
 - dump_urls: If URLs should be dumped instead of downloaded from.
 - jobs: Maximum number of threads to perform downloads, one thread per download.
 - rate_limit:  Rate limit in requests per second
+- template: Custom path template for downloads
+- image_template: Custom path template for image downloads
+- video_template: Custom path template for video downloads
 """
 def main( urls: List[str]
         , dst: Path
@@ -223,7 +299,18 @@ def main( urls: List[str]
         , offsets: Tuple[Optional[int], Optional[int]]
         , dump_urls: bool
         , jobs: int
-        , rate_limit: int = 2) -> None:
+        , rate_limit: int = 2
+        , template: Optional[str] = None
+        , image_template: Optional[str] = None
+        , video_template: Optional[str] = None) -> None:
+    template_manager = None
+    if template:
+        template_manager = TemplateManager(dst, template, image_template, video_template)
+        logger.info(f'Using template {template}')
+        if image_template:
+            logger.info(f'Using image template {image_template}')
+        if video_template:
+            logger.info(f'Using video template {video_template}')
 
     rate_limiter = RateLimiter(rate_limit)
     logger.info(f'Rate limit set to {rate_limit} requests/s')
@@ -245,7 +332,7 @@ def main( urls: List[str]
             if offsets[0] is not None or offsets[1] is not None:
                 logger.warning('Start and end offsets are ignored when downloading a post')
             user = segments[-3]
-            named_urls = process_post(url, skip_img, skip_vid, rate_limiter)
+            named_urls = process_post(url, skip_img, skip_vid, rate_limiter, template_manager)
 
         # Fetch URLs to download media from pre-fetched media
         elif segments[-4] == 'data':
@@ -260,12 +347,19 @@ def main( urls: List[str]
         else:
             logger.debug('URL is suspected to be a page')
             user = segments[-1]
-            named_urls = process_page(url, skip_img, skip_vid, offsets, rate_limiter)
+            named_urls = process_page(url, skip_img, skip_vid, offsets, rate_limiter, template_manager)
 
-        # Remove URLs of files that already exist
-        dst_root = dst / user
-        logger.info(f'Begin hashing files in {dst_root}')
-        named_urls = purge_duplicate_urls(dst_root, named_urls)
+        # When using templates the destination is already in the path
+        if template_manager:
+            dst_root = dst
+            logger.info(f'Begin hashing files in {dst_root}')
+            named_urls = purge_duplicate_urls(dst_root, named_urls)
+        else:
+            # Remove URLs of files that already exist
+            dst_root = dst / user
+            logger.info(f'Begin hashing files in {dst_root}')
+            named_urls = purge_duplicate_urls(dst_root, named_urls)
+
         logger.info(f'New number of media files to download is {len(named_urls)}')
 
         # Conditionally dump the URLs and return
@@ -274,13 +368,18 @@ def main( urls: List[str]
                 print(f'{nu.name}\t{nu.url}') # Print is used here instead of logging for a better UX
             return
 
-        # Create the folder tree for the download destination
-        create_folder_tree(dst, user, skip_img, skip_vid)
+        if template_manager:
+            # create folder based on template
+            dst.mkdir(exist_ok=True, parents=True)
+            dst_pics = dst
+            dst_vids = dst
+        else:
+            # Create the folder tree for the download destination
+            create_folder_tree(dst, user, skip_img, skip_vid)
+            dst_pics = dst_root / 'pics'
+            dst_vids = dst_root / 'vids'
 
-        # Perform the downloads
-        dst_pics = dst_root / 'pics'
-        dst_vids = dst_root / 'vids'
-        logger.info(f'Downloading to {dst / user}')
-        multithread_download(named_urls, dst_pics, dst_vids, workers=jobs, rate_limiter=rate_limiter)
+        logger.info(f'Downloading to {dst / user if not template_manager else dst}')
+        multithread_download(named_urls, dst_pics, dst_vids, workers=jobs, rate_limiter=rate_limiter, use_template=template_manager is not None)
 
     return

--- a/src/coomerscraper/rate_limiter.py
+++ b/src/coomerscraper/rate_limiter.py
@@ -1,0 +1,24 @@
+import time
+from threading import Lock
+
+class RateLimiter:
+    def __init__(self, requests_per_second: int = 2):
+        self.requests_per_second = requests_per_second
+        self.min_interval = 1.0 / requests_per_second if requests_per_second > 0 else 0
+        self.last_request_time = 0.0
+        self.lock = Lock()
+
+    def wait(self):
+        if self.requests_per_second <= 0:
+            return
+
+        with self.lock:
+            current_time = time.monotonic()
+            time_since_last_request = current_time - self.last_request_time
+
+            if time_since_last_request < self.min_interval:
+                sleep_time = self.min_interval - time_since_last_request
+                time.sleep(sleep_time)
+
+            # update using monotonic time
+            self.last_request_time = time.monotonic()

--- a/src/coomerscraper/template.py
+++ b/src/coomerscraper/template.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+import re
+from typing import Dict, Optional
+
+
+class PathTemplate:
+    TAGS = {
+        '<t:service>': 'service',
+        '<t:creator>': 'creator',
+        '<t:post>': 'post',
+        '<t:index>': 'index',
+        '<t:filename>': 'filename',
+        '<t:filehash>': 'filehash',
+        '<t:extension>': 'extension',
+        '<t:date>' : 'date',
+        '<t:id>' : 'id'
+    }
+
+    def __init__(self, template_str: str, output_dir: Path):
+        self.template_str = template_str
+        self.output_dir = output_dir
+
+    def format(self, context: Dict[str, str]) -> Path:
+        """
+        args: context: dict. containing values for template tags, keys should match TAGS values above
+        returns: path: the formatted path
+        """
+
+        result = self.template_str
+        for tag, key in self.TAGS.items():
+            value = context.get(key, '')
+            if value is None:
+                value = ''
+            result = result.replace(tag, str(value))
+
+        result = self.sanitize_path(result)
+
+        return self.output_dir / result
+
+    @staticmethod
+    def sanitize_path(path_str: str) -> str:
+        """
+        replaces all invalid path characters with underscores
+        invalid characters for windows: <>:"/\|?*
+        """
+        invalid = r'[<>:"|?*]'
+        path_str = re.sub(invalid, '_', path_str)
+        parts = path_str.split('/')
+        parts = [p.strip('.') for p in parts if p.strip('.')]
+        return '/'.join(parts)
+
+
+class TemplateManager:
+    def __init__(self, output_dir: Path,
+                 default_template: Optional[str] = None,
+                 image_template: Optional[str] = None,
+                 video_template: Optional[str] = None):
+        self.output_dir = output_dir
+
+        if default_template is None:
+            default_template = "<ks:creator>/<ks:filename><ks:extension>"
+
+        self.default_template = PathTemplate(default_template, output_dir)
+        self.image_template = PathTemplate(image_template, output_dir) if image_template else None
+        self.video_template = PathTemplate(video_template, output_dir) if video_template else None
+
+    def get_path(self, context: Dict[str, str], is_image: bool = False, is_video: bool = False) -> Path:
+        if is_image and self.image_template:
+            return self.image_template.format(context)
+        elif is_video and self.video_template:
+            return self.video_template.format(context)
+        else:
+            return self.default_template.format(context)

--- a/src/coomerscraper/utils.py
+++ b/src/coomerscraper/utils.py
@@ -33,17 +33,30 @@ Returns a set of unique hashes from root.
 """
 def compute_file_hashes(root: Path) -> Set[str]:
     hashes = set()
+    if not root.exists():
+        logger.debug(f'compute_file_hashes: root does not exist: {root}')
+        return hashes
+
     for file in root.glob('**/*'):
         if file.is_dir() or file.suffix == '.part':
+            logger.debug(f'Skipping file: {file} (dir or .part)')
             continue
+
+        # Verbose: announce which file we're hashing right now
+        logger.debug(f'Hashing file: {file}')
+
         with file.open('rb') as f:
             curr_hash = hashlib.sha256()
-            while(True):
+            while True:
                 chunk = f.read(10 * 1024)
                 if not chunk:
                     break
                 curr_hash.update(chunk)
-            hashes.add(curr_hash.hexdigest())
+            file_hash = curr_hash.hexdigest()
+            hashes.add(file_hash)
+
+        # Verbose: show computed hash for the file
+        logger.debug(f'Computed hash {file_hash} for {file}')
     return hashes
 
 


### PR DESCRIPTION
This PR introduces two new features for better user control: a rate limiter and templates.

### Rate Limiter
- Adds a requests per second limit which is prompted during runtime (or use the `--rate-limit` flag)
- Defaults to 2 req/s

### Templates
- Adds a way to allow users to define how data is structured
- Default behavior remains unchanged for users who do not want to use templates
- This function does not show in the prompt as I would consider this an "advanced' feature.
- Usage for this function is available in the README.md
- Inspired by elvis972602/Kemono-scraper
