### PR TITLE
Feat/abort downloads eventually

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ coomerscraper
 ```
 usage: coomerscraper [-h] [-c] [--dump-urls] [-j JOBS] [--log-file LOG_FILE] [--log-level LOG_LEVEL]
                      [--offset-end END] [--offset-start START] [-o OUT] [--skip-imgs] [--skip-vids]
-                     [urls ...]
+                     [--retries RETRIES] [urls ...]
 
 Coomer and Kemono scraper
 
@@ -64,6 +64,7 @@ options:
   -o, --out OUT         download destination (default: CWD)
   --skip-imgs           skip image downloads
   --skip-vids           skip video downloads
+  --retries RETRIES     number of retries per media file (default: None which results in unlimited)
 ```
 
 The URL can be a page for a creator, a post from a creator, or a single media file. The starting and ending offsets are only respected when downloading from a page. When downloading a single media file, the creator name cannot be determined, thus goes in a subfolder named "unknown."

--- a/src/coomerscraper/__main__.py
+++ b/src/coomerscraper/__main__.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 """
 Parse the program arguments or read them from stdin
 """
-def get_arguments() -> Tuple[List[str], Path, bool, bool, Tuple[int,int], bool, int]:
+def get_arguments() -> Tuple[List[str], Path, bool, bool, Tuple[int,int], bool, int, int]:
         # Initialize arguments for CLI use
     parser = argparse.ArgumentParser(description='Coomer and Kemono scraper')
     parser.exit_on_error = False
@@ -30,6 +30,7 @@ def get_arguments() -> Tuple[List[str], Path, bool, bool, Tuple[int,int], bool, 
     parser.add_argument('-o', '--out', type=str, default=os.getcwd(), help='download destination (default: CWD)')
     parser.add_argument('--skip-imgs', action='store_true', help='skip image downloads')
     parser.add_argument('--skip-vids', action='store_true', help='skip video downloads')
+    parser.add_argument('--retries', type=int, default=None, dest='retries', help='number of retries per media file (default: None which results in unlimited)')
 
     # Handle the special case of logging data
     log_file = None
@@ -78,6 +79,7 @@ def get_arguments() -> Tuple[List[str], Path, bool, bool, Tuple[int,int], bool, 
         offs_end = args.end
         dump_urls = args.dump_urls
         jobs = args.jobs
+        retries = args.retries
         assert len(urls) > 0
         logger.debug('Usage: non-interactive')
 
@@ -95,6 +97,7 @@ def get_arguments() -> Tuple[List[str], Path, bool, bool, Tuple[int,int], bool, 
         offs_end = None
         dump_urls = False
         confirm = True
+        retries = None
 
     # Allow the user to confirm information
     if(confirm):
@@ -106,13 +109,14 @@ def get_arguments() -> Tuple[List[str], Path, bool, bool, Tuple[int,int], bool, 
         logger.info(f'Starting offset is {offs_start}')
         logger.info(f'Ending offset is {offs_end}')
         logger.info(f'There will be {jobs} concurrent download threads')
+        logger.info(f'On each media file {retries} retries will be made')
         print()
         confirmed = input('Continue to download (Y/n): ')
         if len(confirmed) > 0 and confirmed.lower()[0] != 'y':
             exit()
 
     # Return parsed arguments
-    return urls, Path(dst), skip_img, skip_vid, (offs_start, offs_end), dump_urls, jobs
+    return urls, Path(dst), skip_img, skip_vid, (offs_start, offs_end), dump_urls, jobs, retries
 
 
 
@@ -121,7 +125,7 @@ Driver function to handle argument parsing and sanity checks before going to coo
 """
 def main():
     # Get the program arguments or read them from stdin
-    urls, dst, skip_img, skip_vid, offsets, dump_urls, jobs = get_arguments()
+    urls, dst, skip_img, skip_vid, offsets, dump_urls, jobs, retries = get_arguments()
 
     # Sanity check skip flags
     if skip_img and skip_vid:
@@ -144,7 +148,7 @@ def main():
     urls = [ sanitize_url(u) for u in urls ]
 
     # Proceed with coomer-specific details...
-    coom_main(urls, dst, skip_img, skip_vid, offsets, dump_urls, jobs)
+    coom_main(urls, dst, skip_img, skip_vid, offsets, dump_urls, jobs, retries)
     
 
 

--- a/src/coomerscraper/coom.py
+++ b/src/coomerscraper/coom.py
@@ -215,6 +215,7 @@ Driver function to download media from Coomer or Kemono
 - offsets: Post offsets to start from and end at when downloading a page.
 - dump_urls: If URLs should be dumped instead of downloaded from.
 - jobs: Maximum number of threads to perform downloads, one thread per download.
+- retries: Number of retries per media file
 """
 def main( urls: List[str]
         , dst: Path
@@ -222,7 +223,8 @@ def main( urls: List[str]
         , skip_vid: bool
         , offsets: Tuple[Optional[int], Optional[int]]
         , dump_urls: bool
-        , jobs: int) -> None:
+        , jobs: int
+        , retries: int) -> None:
 
     # Loop through the URLs to get more URLs
     for url in urls:
@@ -277,6 +279,6 @@ def main( urls: List[str]
         dst_pics = dst_root / 'pics'
         dst_vids = dst_root / 'vids'
         logger.info(f'Downloading to {dst / user}')
-        multithread_download(named_urls, dst_pics, dst_vids, workers=jobs)
+        multithread_download(named_urls, dst_pics, dst_vids, workers=jobs, retries=retries)
 
     return

--- a/src/coomerscraper/coom.py
+++ b/src/coomerscraper/coom.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from sys import maxsize
 from typing import List, Optional, Tuple
 
-from .networking import ( api_fetch_post_multi, api_fetch_post_single
+from .networking import ( api_fetch_post_multi, api_fetch_post_single, api_fetch_creator_profile
                         , multithread_download, NamedUrl, IMG_EXTS, VID_EXTS )
 from .utils import base_url, compute_file_hashes, create_folder_tree, round_offsets, to_camel
 
@@ -172,6 +172,19 @@ def process_page( url: str
 
 
 """
+Get creator name as string. Some services only use integer IDs which can be 
+replaced by clear names using this function.
+Returns creator name as string
+"""
+def get_creator_name(base: str, service: str, creator: str) -> List[NamedUrl]:
+    profile = api_fetch_creator_profile(base, service, creator)
+    if profile:
+        return f'{profile["name"]}_{service}'
+    else:
+        return f'{creator}_{service}'
+
+
+"""
 Remove duplicate URLs based on the SHA-256 hash of existing files.
 Note that since URLs are hashes, there should be no duplicates between posts.
 - dst: Directory to check for existing files.
@@ -227,7 +240,7 @@ def main( urls: List[str]
             logger.debug('URL is suspected to be a post')
             if offsets[0] is not None or offsets[1] is not None:
                 logger.warning('Start and end offsets are ignored when downloading a post')
-            user = segments[-3]
+            user = get_creator_name(base_url(url), segments[-5], segments[-3])
             named_urls = process_post(url, skip_img, skip_vid)
 
         # Fetch URLs to download media from pre-fetched media
@@ -242,7 +255,7 @@ def main( urls: List[str]
         # Fetch URLs to download media from a page
         else:
             logger.debug('URL is suspected to be a page')
-            user = segments[-1]
+            user = get_creator_name(base_url(url), segments[-3], segments[-1])
             named_urls = process_page(url, skip_img, skip_vid, offsets)
 
         # Remove URLs of files that already exist

--- a/src/coomerscraper/networking.py
+++ b/src/coomerscraper/networking.py
@@ -49,8 +49,9 @@ Download a single URL, cycling through random load-balancing servers.
 - dst: Destination of the URL.
 - slot: Position in the progress rendering
 - q: The queue that this job belongs to
+- retries: Number of retries per media file
 """
-def _download( url: NamedUrl, dst: Path, slot: int, q: queue.Queue ) -> None:
+def _download( url: NamedUrl, dst: Path, slot: int, q: queue.Queue, retries: int ) -> None:
     server_ident = randrange(4) + 1
     static_url = url.url[10:]
     tmp = dst.with_suffix(dst.suffix + '.part')
@@ -91,7 +92,7 @@ def _download( url: NamedUrl, dst: Path, slot: int, q: queue.Queue ) -> None:
         except (requests.RequestException, requests.exceptions.ReadTimeout):
             q.put(_ProgressUpdate(slot, done, total, url.name, server_ident, paused=True))
             errcnt += 1
-            if errcnt < 200:
+            if retries is None or errcnt < retries:
                 time.sleep(THROTTLE_TIME)
                 server_ident = randrange(3) + 1
                 continue
@@ -183,6 +184,7 @@ Download a list of NamedUrl using multithreading, checking for duplicates.
 - dst_pics: Path to download pictures to.
 - dst_vids: Path to download videos to.
 - workers: Maximum number of threads to use for downloading.
+- retries: Number of retries per media file
 Returns the number of unique downloads successfully performed.
 """
 def multithread_download( urls: List[NamedUrl]
@@ -190,6 +192,7 @@ def multithread_download( urls: List[NamedUrl]
                         , dst_vids: Path
                         , hashes: dict[bytes, Path] = {}
                         , workers: int = 8
+                        , retries: int = None
                         ) -> dict[bytes, Path]:
     q: queue.Queue = queue.Queue()
     url_iter = iter(urls)
@@ -207,7 +210,7 @@ def multithread_download( urls: List[NamedUrl]
             try:
                 next_url = next(url_iter)
                 dst = (dst_pics if next_url.url.split('.')[-1] in IMG_EXTS else dst_vids) / next_url.name
-                pool.submit(_download, next_url, dst, slot, q)
+                pool.submit(_download, next_url, dst, slot, q, retries)
                 return True
             except StopIteration:
                 return False

--- a/src/coomerscraper/networking.py
+++ b/src/coomerscraper/networking.py
@@ -150,6 +150,31 @@ def api_fetch_post_single(base: str, service: str, creator: str, post_id: str) -
 
 
 """
+Use the Coomer/Kemono API to fetch a creator profile.
+- base: Base URL for the API (includes up the the TLD).
+- service: Service the media originates from.
+- creator: Creator of the media.
+Returns a creator profile.
+"""
+def api_fetch_creator_profile(base: str, service: str, creator: str) -> dict:
+    api_url = f'{base}/api/v1/{service}/user/{creator}/profile'
+    while True:
+        try:
+            res = requests.get(api_url, headers={'accept': 'text/css'})
+        except Exception:
+            if res.status_code in [429, 403]:
+                time.sleep(THROTTLE_TIME)
+        else:
+            break
+
+    if res.status_code != 200:
+        logger.error(f'Failed to fetch creator profile using the API ({api_url}) --> {res.status_code}')
+        return {}
+
+    return res.json()
+
+
+"""
 Download a list of NamedUrl using multithreading, checking for duplicates.
 - urls: List of NamedUrl to download.
 - dst_pics: Path to download pictures to.

--- a/src/coomerscraper/networking.py
+++ b/src/coomerscraper/networking.py
@@ -55,6 +55,7 @@ def _download( url: NamedUrl, dst: Path, slot: int, q: queue.Queue ) -> None:
     static_url = url.url[10:]
     tmp = dst.with_suffix(dst.suffix + '.part')
     total = None
+    errcnt = 0
 
     while True:
         headers = { 'Connection': 'close' }
@@ -81,6 +82,7 @@ def _download( url: NamedUrl, dst: Path, slot: int, q: queue.Queue ) -> None:
                     for chunk in res.iter_content(chunk_size=CHUNK_SIZE):
                         if not chunk:
                             continue
+                        errcnt = 0
                         f.write(chunk)
                         done += len(chunk)
                         q.put(_ProgressUpdate(slot, done, total, url.name, server_ident))
@@ -88,13 +90,14 @@ def _download( url: NamedUrl, dst: Path, slot: int, q: queue.Queue ) -> None:
 
         except (requests.RequestException, requests.exceptions.ReadTimeout):
             q.put(_ProgressUpdate(slot, done, total, url.name, server_ident, paused=True))
-            time.sleep(THROTTLE_TIME)
-            server_ident = randrange(3) + 1
-            q.put(_ProgressUpdate(slot, done, total, url.name, server_ident))
-
-        else:
-            q.put(_ProgressUpdate(slot, done, total, url.name, server_ident, finished=True))
-            return
+            errcnt += 1
+            if errcnt < 200:
+                time.sleep(THROTTLE_TIME)
+                server_ident = randrange(3) + 1
+                continue
+        
+        q.put(_ProgressUpdate(slot, done, total, url.name, server_ident, finished=True))
+        return
 
 
 """

--- a/src/coomerscraper/networking.py
+++ b/src/coomerscraper/networking.py
@@ -63,7 +63,7 @@ def _download( url: NamedUrl, dst: Path, slot: int, q: queue.Queue ) -> None:
             headers['Range'] = f'bytes={done}-'
         
         real_url = f'https://n{server_ident}{static_url}'
-        q.put(_ProgressUpdate(slot, done, total, url.name, server_ident))
+        q.put(_ProgressUpdate(slot, done, total, str(dst), server_ident))
 
         try:
             with requests.get(real_url, stream=True, timeout=(3, 3), headers=headers) as res:
@@ -83,17 +83,17 @@ def _download( url: NamedUrl, dst: Path, slot: int, q: queue.Queue ) -> None:
                             continue
                         f.write(chunk)
                         done += len(chunk)
-                        q.put(_ProgressUpdate(slot, done, total, url.name, server_ident))
+                        q.put(_ProgressUpdate(slot, done, total, str(dst), server_ident))
                 tmp.replace(dst)
 
         except (requests.RequestException, requests.exceptions.ReadTimeout):
-            q.put(_ProgressUpdate(slot, done, total, url.name, server_ident, paused=True))
+            q.put(_ProgressUpdate(slot, done, total, str(dst), server_ident, paused=True))
             time.sleep(THROTTLE_TIME)
             server_ident = randrange(3) + 1
-            q.put(_ProgressUpdate(slot, done, total, url.name, server_ident))
+            q.put(_ProgressUpdate(slot, done, total, str(dst), server_ident))
 
         else:
-            q.put(_ProgressUpdate(slot, done, total, url.name, server_ident, finished=True))
+            q.put(_ProgressUpdate(slot, done, total, str(dst), server_ident, finished=True))
             return
 
 


### PR DESCRIPTION
Currently the script can be trapped in an endless loop trying to download media files if they are not available anymore on the servers. To avoid this, the changes in this PR count the download exceptions and stops retrying after 200 failed attempts.

EDIT: Added an argument `--retries RETRIES` for this as suggested in https://github.com/A-Coom/coomer.party-scraper/issues/25